### PR TITLE
modbus sensor: string data_type

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,0 +1,73 @@
+"""Constants used in modbus integration."""
+
+# configuration names
+CONF_BAUDRATE = "baudrate"
+CONF_BYTESIZE = "bytesize"
+CONF_HUB = "hub"
+CONF_PARITY = "parity"
+CONF_STOPBITS = "stopbits"
+CONF_REGISTER = "register"
+CONF_REGISTER_TYPE = "register_type"
+CONF_REGISTERS = "registers"
+CONF_REVERSE_ORDER = "reverse_order"
+CONF_SCALE = "scale"
+CONF_COUNT = "count"
+CONF_PRECISION = "precision"
+CONF_OFFSET = "offset"
+CONF_COILS = "coils"
+
+# integration names
+DEFAULT_HUB = "default"
+MODBUS_DOMAIN = "modbus"
+
+# data types
+DATA_TYPE_CUSTOM = "custom"
+DATA_TYPE_FLOAT = "float"
+DATA_TYPE_INT = "int"
+DATA_TYPE_UINT = "uint"
+DATA_TYPE_STRING = "string"
+
+# call types
+CALL_TYPE_COIL = "coil"
+CALL_TYPE_DISCRETE = "discrete_input"
+CALL_TYPE_REGISTER_HOLDING = "holding"
+CALL_TYPE_REGISTER_INPUT = "input"
+
+# the following constants are TBD.
+# changing those in general causes a breaking change, because
+# the contents of configuration.yaml needs to be updated,
+# therefore they are left to a later date.
+# but kept here, with a reference to the file using them.
+
+# __init.py
+ATTR_ADDRESS = "address"
+ATTR_HUB = "hub"
+ATTR_UNIT = "unit"
+ATTR_VALUE = "value"
+SERVICE_WRITE_COIL = "write_coil"
+SERVICE_WRITE_REGISTER = "write_register"
+
+# binary_sensor.py
+CONF_INPUTS = "inputs"
+CONF_INPUT_TYPE = "input_type"
+CONF_ADDRESS = "address"
+
+# sensor.py
+# CONF_DATA_TYPE = "data_type"
+
+# switch.py
+CONF_STATE_OFF = "state_off"
+CONF_STATE_ON = "state_on"
+CONF_VERIFY_REGISTER = "verify_register"
+CONF_VERIFY_STATE = "verify_state"
+
+# climate.py
+CONF_TARGET_TEMP = "target_temp_register"
+CONF_CURRENT_TEMP = "current_temp_register"
+CONF_CURRENT_TEMP_REGISTER_TYPE = "current_temp_register_type"
+CONF_DATA_TYPE = "data_type"
+CONF_DATA_COUNT = "data_count"
+CONF_UNIT = "temperature_unit"
+CONF_MAX_TEMP = "max_temp"
+CONF_MIN_TEMP = "min_temp"
+CONF_STEP = "temp_step"

--- a/sensor.py
+++ b/sensor.py
@@ -1,0 +1,270 @@
+"""Support for Modbus Register sensors."""
+import logging
+import struct
+from typing import Any, Optional, Union
+
+from pymodbus.exceptions import ConnectionException, ModbusException
+from pymodbus.pdu import ExceptionResponse
+import voluptuous as vol
+
+from homeassistant.components.sensor import DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_DEVICE_CLASS,
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_SLAVE,
+    CONF_STRUCTURE,
+    CONF_UNIT_OF_MEASUREMENT,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import (
+    CALL_TYPE_REGISTER_HOLDING,
+    CALL_TYPE_REGISTER_INPUT,
+    CONF_COUNT,
+    CONF_DATA_TYPE,
+    CONF_HUB,
+    CONF_PRECISION,
+    CONF_REGISTER,
+    CONF_REGISTER_TYPE,
+    CONF_REGISTERS,
+    CONF_REVERSE_ORDER,
+    CONF_SCALE,
+    DATA_TYPE_CUSTOM,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRING,
+    DATA_TYPE_UINT,
+    DEFAULT_HUB,
+    MODBUS_DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def number(value: Any) -> Union[int, float]:
+    """Coerce a value to number without losing precision."""
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str):
+        try:
+            value = int(value)
+            return value
+        except (TypeError, ValueError):
+            pass
+
+    try:
+        value = float(value)
+        return value
+    except (TypeError, ValueError):
+        raise vol.Invalid(f"invalid number {value}")
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_REGISTERS): [
+            {
+                vol.Required(CONF_NAME): cv.string,
+                vol.Required(CONF_REGISTER): cv.positive_int,
+                vol.Optional(CONF_COUNT, default=1): cv.positive_int,
+                vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_INT): vol.In(
+                    [
+                        DATA_TYPE_INT,
+                        DATA_TYPE_UINT,
+                        DATA_TYPE_FLOAT,
+                        DATA_TYPE_STRING,
+                        DATA_TYPE_CUSTOM,
+                    ]
+                ),
+                vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+                vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
+                vol.Optional(CONF_OFFSET, default=0): number,
+                vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
+                vol.Optional(
+                    CONF_REGISTER_TYPE, default=CALL_TYPE_REGISTER_HOLDING
+                ): vol.In([CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]),
+                vol.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
+                vol.Optional(CONF_SCALE, default=1): number,
+                vol.Optional(CONF_SLAVE): cv.positive_int,
+                vol.Optional(CONF_STRUCTURE): cv.string,
+                vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+            }
+        ]
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Modbus sensors."""
+    sensors = []
+    data_types = {DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"}}
+    data_types[DATA_TYPE_UINT] = {1: "H", 2: "I", 4: "Q"}
+    data_types[DATA_TYPE_FLOAT] = {1: "e", 2: "f", 4: "d"}
+
+    for register in config[CONF_REGISTERS]:
+        structure = ">i"
+        if register[CONF_DATA_TYPE] == DATA_TYPE_STRING:
+            structure = str(register[CONF_COUNT] * 2) + "s"
+        elif register[CONF_DATA_TYPE] != DATA_TYPE_CUSTOM:
+            try:
+                structure = (
+                    f">{data_types[register[CONF_DATA_TYPE]][register[CONF_COUNT]]}"
+                )
+            except KeyError:
+                _LOGGER.error(
+                    "Unable to detect data type for %s sensor, try a custom type",
+                    register[CONF_NAME],
+                )
+                continue
+        else:
+            structure = register.get(CONF_STRUCTURE)
+
+        try:
+            size = struct.calcsize(structure)
+        except struct.error as err:
+            _LOGGER.error("Error in sensor %s structure: %s", register[CONF_NAME], err)
+            continue
+
+        if register[CONF_COUNT] * 2 != size:
+            _LOGGER.error(
+                "Structure size (%d bytes) mismatch registers count (%d words)",
+                size,
+                register[CONF_COUNT],
+            )
+            continue
+
+        hub_name = register[CONF_HUB]
+        hub = hass.data[MODBUS_DOMAIN][hub_name]
+        sensors.append(
+            ModbusRegisterSensor(
+                hub,
+                register[CONF_NAME],
+                register.get(CONF_SLAVE),
+                register[CONF_REGISTER],
+                register[CONF_REGISTER_TYPE],
+                register.get(CONF_UNIT_OF_MEASUREMENT),
+                register[CONF_COUNT],
+                register[CONF_REVERSE_ORDER],
+                register[CONF_SCALE],
+                register[CONF_OFFSET],
+                structure,
+                register[CONF_PRECISION],
+                register[CONF_DATA_TYPE],
+                register.get(CONF_DEVICE_CLASS),
+            )
+        )
+
+    if not sensors:
+        return False
+    add_entities(sensors)
+
+
+class ModbusRegisterSensor(RestoreEntity):
+    """Modbus register sensor."""
+
+    def __init__(
+        self,
+        hub,
+        name,
+        slave,
+        register,
+        register_type,
+        unit_of_measurement,
+        count,
+        reverse_order,
+        scale,
+        offset,
+        structure,
+        precision,
+        data_type,
+        device_class,
+    ):
+        """Initialize the modbus register sensor."""
+        self._hub = hub
+        self._name = name
+        self._slave = int(slave) if slave else None
+        self._register = int(register)
+        self._register_type = register_type
+        self._unit_of_measurement = unit_of_measurement
+        self._count = int(count)
+        self._reverse_order = reverse_order
+        self._scale = scale
+        self._offset = offset
+        self._precision = precision
+        self._structure = structure
+        self._data_type = data_type
+        self._device_class = device_class
+        self._value = None
+        self._available = True
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await self.async_get_last_state()
+        if not state:
+            return
+        self._value = state.state
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._value
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def device_class(self) -> Optional[str]:
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._available
+
+    def update(self):
+        """Update the state of the sensor."""
+        try:
+            if self._register_type == CALL_TYPE_REGISTER_INPUT:
+                result = self._hub.read_input_registers(
+                    self._slave, self._register, self._count
+                )
+            else:
+                result = self._hub.read_holding_registers(
+                    self._slave, self._register, self._count
+                )
+        except ConnectionException:
+            self._available = False
+            return
+
+        if isinstance(result, (ModbusException, ExceptionResponse)):
+            self._available = False
+            return
+
+        registers = result.registers
+        if self._reverse_order:
+            registers.reverse()
+
+        byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
+        if self._data_type != DATA_TYPE_STRING:
+            val = struct.unpack(self._structure, byte_string)[0]
+            val = self._scale * val + self._offset
+            if isinstance(val, int):
+                self._value = str(val)
+                if self._precision > 0:
+                    self._value += "." + "0" * self._precision
+            else:
+                self._value = f"{val:.{self._precision}f}"
+        else:
+            self._value = byte_string.decode()
+
+        self._available = True


### PR DESCRIPTION
Adds support for a string data_type. This allows the reading of holding registers that contain ascii string data

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change enables a string data_type to provide support for reading holding registers that contain ascii text. The length of text to be read is based on the count of holding registers read.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
# Shows the current date and time. The date and time is updated continuously.
# The clock does not begin counting until a setting different from default has been made in parameter 0-70 Date and Time.
# This is a 16 character string.
    - name: D1 Date Time Readout
      hub: hub1
      slave: 1 
      register: 889
      count: 8
      data_type: string

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #34943
- This PR is related to issue: 34943
- Link to documentation pull request: #13302

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
